### PR TITLE
WS-1122: deploys removal of an unused "print logo" to avoid missing alt…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
         "ucdavis/sitefarm_seed": "dev-8.x-1.x",
-        "uclalibrary/ucla_gateway": "dev-master"
+        "uclalibrary/ucla_gateway": "1.0.*"
     },
     "require-dev": {
         "behat/mink": "~1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb9bf5371881af37b55b0817954896d3",
+    "content-hash": "c7c297bacb3d1925c9deffd6801c98b3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5559,7 +5559,7 @@
             "version": "dev-8.x-1.x",
             "source": {
                 "type": "git",
-                "url": "ssh://git@sitefarm_seed.github.com/uclalibrary/sitefarm_seed.git",
+                "url": "git@github.com:uclalibrary/sitefarm_seed.git",
                 "reference": "0e336e565ae1eb7177ba9ecf05504e60aa9f8fec"
             },
             "dist": {
@@ -5681,12 +5681,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/UCLALibrary/ucla_gateway.git",
-                "reference": "e89ed5ca24e48a62521b3a22757db953dca3f84c"
+                "reference": "159656253c425581b0562afc13384d62c989301b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/uclalibrary/ucla_gateway/zipball/e89ed5ca24e48a62521b3a22757db953dca3f84c",
-                "reference": "e89ed5ca24e48a62521b3a22757db953dca3f84c",
+                "url": "https://api.github.com/repos/UCLALibrary/ucla_gateway/zipball/159656253c425581b0562afc13384d62c989301b",
+                "reference": "159656253c425581b0562afc13384d62c989301b",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -5704,7 +5704,7 @@
                 }
             ],
             "description": "The UCLA Gateway theme.",
-            "time": "2017-09-21 23:16:13"
+            "time": "2017-09-25 19:12:25"
         },
         {
             "name": "webflo/drupal-finder",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f35ae953c3536994fd4383bea5b3f6e",
+    "content-hash": "0fb88f6648a41ac223ff835fb34cac46",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5677,16 +5677,16 @@
         },
         {
             "name": "uclalibrary/ucla_gateway",
-            "version": "dev-master",
+            "version": "1.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UCLALibrary/ucla_gateway.git",
-                "reference": "159656253c425581b0562afc13384d62c989301b"
+                "reference": "2cabbbf8a7f959a02301cb688053d56696f07756"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UCLALibrary/ucla_gateway/zipball/159656253c425581b0562afc13384d62c989301b",
-                "reference": "159656253c425581b0562afc13384d62c989301b",
+                "url": "https://api.github.com/repos/UCLALibrary/ucla_gateway/zipball/2cabbbf8a7f959a02301cb688053d56696f07756",
+                "reference": "2cabbbf8a7f959a02301cb688053d56696f07756",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -5704,7 +5704,7 @@
                 }
             ],
             "description": "The UCLA Gateway theme.",
-            "time": "2017-09-25 22:49:35"
+            "time": "2017-09-25T22:49:35+00:00"
         },
         {
             "name": "webflo/drupal-finder",
@@ -8519,8 +8519,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "ucdavis/sitefarm_seed": 20,
-        "uclalibrary/ucla_gateway": 20
+        "ucdavis/sitefarm_seed": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
…property on image tag

My thought was since we are not using any print css then we probably do not need a separate logo for print