### PR TITLE
WS-1124: deploys magnifying glass on searchbar updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9db8a109ba06feed7768a88ea70be607",
+    "content-hash": "5adc917ea720451d0316a5d64ed1c5ee",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5677,16 +5677,16 @@
         },
         {
             "name": "uclalibrary/ucla_gateway",
-            "version": "1.0.16",
+            "version": "1.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UCLALibrary/ucla_gateway.git",
-                "reference": "6bfefa1c24b8aebca5bc8afd0df05587117165a2"
+                "reference": "8597b40bf33de9e28febf57ddc022a5e6aa1d980"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UCLALibrary/ucla_gateway/zipball/6bfefa1c24b8aebca5bc8afd0df05587117165a2",
-                "reference": "6bfefa1c24b8aebca5bc8afd0df05587117165a2",
+                "url": "https://api.github.com/repos/UCLALibrary/ucla_gateway/zipball/8597b40bf33de9e28febf57ddc022a5e6aa1d980",
+                "reference": "8597b40bf33de9e28febf57ddc022a5e6aa1d980",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -5704,7 +5704,7 @@
                 }
             ],
             "description": "The UCLA Gateway theme.",
-            "time": "2017-09-26T04:39:36+00:00"
+            "time": "2017-09-26T19:30:08+00:00"
         },
         {
             "name": "webflo/drupal-finder",


### PR DESCRIPTION
@emb03 here is how I made this:

## Development: Theme update procedure
1. Do theme work and make PR
2. Merge PR on theme repo
3. Make theme update deployment PR in project repo
    1. Fetch all project updates – `git fetch --all`
    2. Checkout topic branch – `git checkout -b deploy-<your-theme-update-topic> upstream/master`
    3. Update your composer lock – `composer update <theme-repo-package>` eg:
        * `composer update uclalibrary/ucla_gateway` _(don't forget `fin exec ...` if you are using docksal)_
        * This will see the latest updates in your theme can put them into you composer.lock file
    4. Commit changes in composer lock – `git add composer.lock && git commit -m "updates to latest theme changes with that thing"`
    5. Push to your fork and make PR
4. Approve and Merge PR and run deployment steps